### PR TITLE
at_hash is not OIDC compliant

### DIFF
--- a/TechnicalSpecification.md
+++ b/TechnicalSpecification.md
@@ -368,7 +368,7 @@ An example:
   ],
   "state": "1OnH3qwltWy81fKqcmjYTqnco9yVQ2gGZXws/DBLNvQ=",
   "nonce": "",
-  "at_hash": "X0MVjwrmMQs/IBzfU2osvw=="
+  "at_hash": "X0MVjwrmMQs_IBzfU2osvw"
 }
 ````
 
@@ -392,7 +392,7 @@ The following claims are presented in the identity token.
 | `state` | `abcdefghijklmnop` - security element. The authentication request’s `state` parameter value.  |
 | `nonce` | `qrstuvwxyzabcdef` - security element. The authentication request’s `nonce` parameter value. Value is present only in case the `nonce` parameter was sent in the authentication request. |
 | `acr` (_Authentication Context Class Reference_) | `high` - level of authentication based on the eIDAS LoA (level of assurance). Possible values: `low`, `substantial`, `high`. The element is not used if the level of authentication is not applicable or is unknown. |
-| `at_hash` | `X0MVjwrmMQs/IBzfU2osvw==` - the access token hash. Not used in TARA. |
+| `at_hash` | `X0MVjwrmMQs_IBzfU2osvw` - the access token hash. Not used in TARA. |
 | `email` | `60001019906@eesti.ee` - the user’s e-mail address. Only issued if an Estonian ID card is used for authenticating the user. Is only read from the SAN extension of the user’s authentication certificate (from the RFC822 type `Subject Alternative Name` field) |
 | `email_verified` | `false` - the e-mail address of the user has been verified. TARA always issues a value `false`. It means that TARA does not verify or issue information on whether or not the user has redirected his/her eesti.ee e-mail address. |
 

--- a/TehnilineKirjeldus.md
+++ b/TehnilineKirjeldus.md
@@ -406,7 +406,7 @@ Näide (identsustõendi sisu e _payload_):
   ],
   "state": "1OnH3qwltWy81fKqcmjYTqnco9yVQ2gGZXws/DBLNvQ=",
   "nonce": "",
-  "at_hash": "X0MVjwrmMQs/IBzfU2osvw=="
+  "at_hash": "X0MVjwrmMQs_IBzfU2osvw"
 }
 ````
 
@@ -430,7 +430,7 @@ Identsustõendis väljastatakse järgmised väited (_claims_).
 | `state` | `abcdefghijklmnop` - turvaelement. Autentimispäringu `state` parameetri väärtus.  |
 | `nonce` | `qrstuvwxyzabcdef` - turvaelement. Autentimispäringu `nonce` parameetri väärtus. Väärtustatud ainult juhul kui autentimispäringus saadeti `nonce` parameeter. |
 | `acr` (_Authentication Context Class Reference_) | `high` - autentimistase, vastavalt eIDAS tasemetele. Võimalikud väärtused: `low` (madal), `substantial` (märkimisväärne), `high` (kõrge). Elementi ei kasutata, kui autentimistase ei kohaldu või pole teada |
-| `at_hash` | `X0MVjwrmMQs/IBzfU2osvw==` - pääsutõendi räsi. TARA-s ei kasutata |
+| `at_hash` | `X0MVjwrmMQs_IBzfU2osvw` - pääsutõendi räsi. TARA-s ei kasutata |
 | `email` | `60001019906@eesti.ee` - kasutaja e-posti aadress. Väljastatakse ainult  Eesti ID-kaardiga kasutaja autentimisel. Loetakse kasutaja autentimissertifikaadi SAN laiendist (RFC822 tüüpi `Subject Alternative Name` väljast) |
 | `email_verified` | `false` - tähendab, et e-posti aadressi kuulumine kasutajale on tuvastatud. TARA väljastab alati väärtuse `false`. See tähendab, et TARA ei kontrolli ega väljasta teavet, kas kasutaja on oma eesti.ee e-postiaadressi suunanud või mitte. |
 | `phone_number`| `+37200000766` - kasutaja telefoninumber. Väljastatakse ainult  Eesti Mobiil-ID'ga kasutaja autentimisel. Telefoninumber esitatakse E.164 formaadis koos riikliku suunakoodiga. | 


### PR DESCRIPTION
Hello,

In the [Technical Specification](https://e-gov.github.io/TARA-Doku/TechnicalSpecification#431-identity-token), the identity token has `at_hash` value that is not according to the [OIDC spec](https://openid.net/specs/openid-connect-core-1_0.html#CodeIDToken).

In short, the value `X0MVjwrmMQs/IBzfU2osvw==` is not a valid base64url encoded string, which is required by OIDC. Instead, it is a regular base64 string.

This seems like an oversight, as the [Demo REST Client](https://github.com/e-gov/TARA-Client/blob/279cdce40aa470498b8db5b476ed99ec99147875/src/main/java/ee/ria/tara/mid/controller/DemoRestController.java#L177) correctly converts the base64 value into the base64url encoded value. If it was following the specifications of this document it should have no reason to do so.

Additionally, when using an OIDC library or a framework, such as the [official .NET one](https://github.com/dotnet/aspnetcore/tree/main/src/Security/Authentication/OpenIdConnect/src) the validation process will always fail. 

Please verify if the `at_hash` value is correct in the documentation.